### PR TITLE
Dev estadisticas

### DIFF
--- a/pages/admin/estadisticas/index.tsx
+++ b/pages/admin/estadisticas/index.tsx
@@ -250,8 +250,6 @@ const Estadisticas: NextPage = () => {
       let date1 = fechasLimite[0]?.toLocaleDateString()
       let date2 = fechasLimite[1]?.toLocaleDateString()
       
-      console.log("aqui ", date1)
-      console.log(date2)
       //let est = all_estations.find(estation => estation.name === estacionOption.name)
       
       let copy = false, finish = false;

--- a/pages/admin/estadisticas/index.tsx
+++ b/pages/admin/estadisticas/index.tsx
@@ -308,6 +308,8 @@ const Estadisticas: NextPage = () => {
             <DateRangePicker
               label="Fechas a visualizar"
               placeholder="Selecciona rango de fechas"
+              minDate={new Date(2022, 0, 1)}
+              maxDate={new Date(new Date().getTime() - 24*60*60*1000)}
               value={fechasLimite}
               onChange={setFechasLimite}
             />

--- a/pages/admin/estadisticas/index.tsx
+++ b/pages/admin/estadisticas/index.tsx
@@ -39,20 +39,29 @@ function getDatesInRange(startDate: Date, endDate: Date) {
 const d1 = new Date('2022-01-01');
 const d2 = new Date(new Date().getTime() - 24*60*60*1000);
 
-console.log(getDatesInRange(d1, d2));
+var dates = getDatesInRange(d1, d2);
 
+function generateData(days: number, max: number, min: number) {
+  const data = []
+  for(let i = 0; i < days; i++) {
+    data.push(Math.floor(Math.random() * (max - min + 1)) + min);
+  }
+  return data;
+}
+
+console.log(generateData(dates.length, 500, 5000))
 
 const all_estations: EstadisticaEstacion[] = [
     {
         name: "VGA1",
-        labels: getDatesInRange(d1, d2),
+        labels: dates,
         datasets: [
           {
             label: 'Potencia total utilizada(KW)',
             fill: true,
             backgroundColor: 'rgba(75,192,192,0.4)',
             borderColor: 'rgba(75,192,192,1)',
-            data: [32000, 27000, 38000, 40000, 25000, 20000, 19000, 21000, 28000, 31000, 24000, 28000]
+            data: generateData(dates.length, 1000, 4000)
           },
           {
             label: `Potencia total contratada`,
@@ -65,14 +74,14 @@ const all_estations: EstadisticaEstacion[] = [
     },
     {
         name: 'VGA2',
-        labels: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+        labels: dates,
         datasets: [
           {
             label: 'Potencia total utilizada(KW)',
             fill: true,
             backgroundColor: 'rgba(75,192,192,0.4)',
             borderColor: 'rgba(75,192,192,1)',
-            data: [33000, 32000, 42000, 41000, 31000, 25000, 21000, 24000, 31000, 29000, 24000, 33000]
+            data: generateData(dates.length, 1000, 4000)
           },
           {
             label: `Potencia total contratada`,
@@ -85,14 +94,14 @@ const all_estations: EstadisticaEstacion[] = [
     },
     {
         name: 'VGA3',
-        labels: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+        labels: dates,
         datasets: [
           {
             label: 'Potencia total utilizada(KW)',
             fill: true,
             backgroundColor: 'rgba(75,192,192,0.4)',
             borderColor: 'rgba(75,192,192,1)',
-            data: [66000, 32000, 42000, 41000, 31000, 25000, 21000, 24000, 31000, 12000, 24000, 33000]
+            data: generateData(dates.length, 1000, 4000)
           },
           {
             label: `Potencia total contratada`,

--- a/pages/admin/estadisticas/index.tsx
+++ b/pages/admin/estadisticas/index.tsx
@@ -194,10 +194,12 @@ const Estadisticas: NextPage = () => {
 
     useEffect(() => { 
       setEstacionGrafica(estations_range()) 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [estacionOpcion]) 
 
     useEffect(() => {
       setEstacionGrafica(estations_range()) 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fechasLimite])
 
     function isThereAWarning(est: EstadisticaEstacion) {

--- a/pages/admin/estadisticas/index.tsx
+++ b/pages/admin/estadisticas/index.tsx
@@ -49,7 +49,19 @@ function generateData(days: number, max: number, min: number) {
   return data;
 }
 
-console.log(generateData(dates.length, 500, 5000))
+function sumaEstaciones(estaciones: EstadisticaEstacion[]) {
+  const data = []
+  console.log(estaciones.length)
+  let sum;
+  for(let i = 0; i < dates.length ; i++) {
+    sum = 0;
+    for(let est = 0; est < estaciones.length; est++) {
+      sum += estaciones[est].datasets[0].data[i]
+    }
+    data.push(sum);
+  }
+  return data;
+}
 
 const all_estations: EstadisticaEstacion[] = [
     {
@@ -125,14 +137,14 @@ const options = {
 const calcularTotalEstaciones = (estaciones: EstadisticaEstacion[]) => {
     const estacionTotal = {
         name: "Todas las estaciones",
-        labels: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+        labels: dates,
         datasets: [
           {
             label: 'Potencia total utilizada(KW)',
             fill: true,
             backgroundColor: 'rgba(75,192,192,0.4)',
             borderColor: 'rgba(75,192,192,1)',
-            data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            data: sumaEstaciones(estaciones)
           },
           {
             label: `Potencia total contratada`,
@@ -145,12 +157,12 @@ const calcularTotalEstaciones = (estaciones: EstadisticaEstacion[]) => {
     }
 
     // Add all the data into estacionTotal
-    estaciones.forEach(estacion => {
+    /*estaciones.forEach(estacion => {
         for(let i = 0; i < estacion.datasets[0].data.length; i++) {
             estacionTotal.datasets[0].data[i] += estacion.datasets[0].data[i]
             estacionTotal.datasets[1].data[i] += estacion.datasets[1].data[i]
         }
-    })
+    })*/
 
     return estacionTotal
 }

--- a/pages/admin/estadisticas/index.tsx
+++ b/pages/admin/estadisticas/index.tsx
@@ -4,6 +4,7 @@ import { Alert, Select } from '@mantine/core';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler } from "chart.js"
 import { Line } from 'react-chartjs-2';
 import { AlertCircle } from "tabler-icons-react";
+import { DateRangePicker } from '@mantine/dates';
 
 
 export interface EstadisticaDataset {
@@ -22,10 +23,29 @@ export interface EstadisticaEstacion {
 
 ChartJS.register( CategoryScale, LinearScale, PointElement, LineElement, Filler, Title, Tooltip, Legend);
 
+
+function getDatesInRange(startDate: Date, endDate: Date) {
+  const date = new Date(startDate.getTime());
+  
+  const dates = [];
+
+  while(date <= endDate) {
+    dates.push(new Date(date).toISOString().slice(0,10));
+    date.setDate(date.getDate()+1);
+  }
+  return dates;
+}
+
+const d1 = new Date('2022-01-01');
+const d2 = new Date(new Date().getTime() - 24*60*60*1000);
+
+console.log(getDatesInRange(d1, d2));
+
+
 const all_estations: EstadisticaEstacion[] = [
     {
         name: "VGA1",
-        labels: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+        labels: getDatesInRange(d1, d2),
         datasets: [
           {
             label: 'Potencia total utilizada(KW)',
@@ -126,6 +146,8 @@ const calcularTotalEstaciones = (estaciones: EstadisticaEstacion[]) => {
     return estacionTotal
 }
 
+
+
 const Estadisticas: NextPage = () => {
 
     const [estacionActiva, setEstacionActiva] = useState('Todas las estaciones')
@@ -197,6 +219,13 @@ const Estadisticas: NextPage = () => {
         setEstacionActiva(value)
     }
 
+
+    const [value, setValue] = useState<[Date | null, Date | null]>([
+      new Date(2022, 3, 30),
+      new Date(2022, 3, 1),
+    ]);
+
+
     return (
         <div>
             <h1>Estadísticas</h1>
@@ -208,6 +237,13 @@ const Estadisticas: NextPage = () => {
                 data={arrayEstaciones}
                 onChange={handleChangeSelected} />
             
+            <DateRangePicker
+              label="Fechas a visualizar"
+              placeholder="Selecciona rango de fechas"
+              value={value}
+              onChange={setValue}
+            />
+
             <Line
                 data={estacionOption}
                 width={100}


### PR DESCRIPTION
Se ha añadido la opción de filtrar el gráfico usando un rango de días. El rango está limitado entre el 1 de Enero de 2022 hasta el día de ayer para evitar escoger días de los cuales no tenemos datos y así evitar errores. 

Los datos generados para el gráfico son generados aleatoriamente, aún no usa nada de la API. 
Ahora mismo no muestra la potencia contratada(lo corregiré en otra tarea que tengo que hacer) y el warning(de la potencia contratada y consumida) también lo modificaré en otra tarea.

