### PR TITLE
Dev warning inicio

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -2,7 +2,9 @@ import type { NextPage } from 'next'
 import dynamic from 'next/dynamic'
 import GeneralInfo from '../../components/GeneralInfo';
 import { Stack, Modal} from '@mantine/core'
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import { AuthContext } from '../../contexts/AuthContext';
+import { PerfilData } from './perfil';
 
 const AdminHome: NextPage = () => {
   // Dynamic import becuase of server side rendering
@@ -10,18 +12,23 @@ const AdminHome: NextPage = () => {
 
   const [opened, setOpened] = useState(true);
   const [count, setCount] = useState('0');
+  const { user, logout } = useContext(AuthContext);
+  const [ profile, setProfile ] = useState<PerfilData>(user!)
+
+  useEffect(() => {
+    setProfile(user!)
+  }, [user])
 
   //No es lo más limpio, pero he pensado en poner el cálculo para saber si hacer el warning aqui también :)
 
   useEffect(() => {
     // Access initial value from session storage
     let pageView = sessionStorage.getItem("pageView");
-    if (pageView == null) {
+    if ((pageView == '0' || pageView == null) && (profile.cargo == 'Administrador' || profile.cargo == 'Jefe' || profile.cargo == 'Responsable')) {
       // Initialize page views count
       pageView = '1';
-      
-    } else {
-      // Increment count
+    } 
+    else {
       pageView = '0';
     }
     // Update session storage
@@ -34,7 +41,7 @@ const AdminHome: NextPage = () => {
   return (
     
     <Stack justify="flex-start" sx={(theme) => ({ minHeight: '100%', backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[8] : theme.colors.gray[0], height: 300 })}>
-        {count == '1' && <Modal
+        {count == '1' &&  <Modal
           opened={opened}
           onClose={() => setOpened(false)}
           title="¡Consumo bajo!"

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,14 +1,47 @@
 import type { NextPage } from 'next'
 import dynamic from 'next/dynamic'
 import GeneralInfo from '../../components/GeneralInfo';
-import { Stack } from '@mantine/core'
+import { Stack, Modal} from '@mantine/core'
+import { useEffect, useState } from 'react';
 
 const AdminHome: NextPage = () => {
   // Dynamic import becuase of server side rendering
   const MapWithNoSSR = dynamic(() => import('../../components/MapElements/Map'), { ssr: false });
 
+  const [opened, setOpened] = useState(true);
+  const [count, setCount] = useState('0');
+
+  //No es lo más limpio, pero he pensado en poner el cálculo para saber si hacer el warning aqui también :)
+
+  useEffect(() => {
+    // Access initial value from session storage
+    let pageView = sessionStorage.getItem("pageView");
+    if (pageView == null) {
+      // Initialize page views count
+      pageView = '1';
+      
+    } else {
+      // Increment count
+      pageView = '0';
+    }
+    // Update session storage
+    sessionStorage.setItem("pageView", pageView);
+    setCount(pageView);
+  }, []); //No dependency to trigger in each page load
+
+
+
   return (
+    
     <Stack justify="flex-start" sx={(theme) => ({ minHeight: '100%', backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[8] : theme.colors.gray[0], height: 300 })}>
+        {count == '1' && <Modal
+          opened={opened}
+          onClose={() => setOpened(false)}
+          title="¡Consumo bajo!"
+          withCloseButton={false}
+        >
+        Se está desaprovechando la potencia contratada, por favor revisa el apartado de estadísticas para más información.
+      </Modal>}
       <GeneralInfo />
       <MapWithNoSSR />
     </Stack>


### PR DESCRIPTION
Se muestra un breve mensaje en la página de inicio si el usuario es Responsable, Jefe o Administrador.

El mensaje se muestra siempre, quiero que solo se muestre solo en caso de que en la página de estadisticas haya un warning, pero para eso necesito los datos de la API. Cuando lo de la API esté hecho, podré copiar y pegar un cálculo que según el resultado mostrará el mensaje o no. Pero por ahora no se puede porque los datos generados para las estadísticas son aleatorios y si uso esos datos no serán los mismos en la página de inicio y en la de estadísticas(ya que se volverían a generar de forma aleatoria). Espero que se entienda :)