### PR TITLE
Cositas warning

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -7,11 +7,8 @@ import { AuthContext } from '../../contexts/AuthContext';
 import { PerfilData } from './perfil';
 
 const AdminHome: NextPage = () => {
-  // Dynamic import becuase of server side rendering
+  // Dynamic import because of server side rendering
   const MapWithNoSSR = dynamic(() => import('../../components/MapElements/Map'), { ssr: false });
-
-  const [opened, setOpened] = useState(true);
-  const [count, setCount] = useState('0');
   const { user, logout } = useContext(AuthContext);
   const [ profile, setProfile ] = useState<PerfilData>(user!)
 
@@ -19,36 +16,8 @@ const AdminHome: NextPage = () => {
     setProfile(user!)
   }, [user])
 
-  //No es lo más limpio, pero he pensado en poner el cálculo para saber si hacer el warning aqui también :)
-
-  useEffect(() => {
-    // Access initial value from session storage
-    let pageView = sessionStorage.getItem("pageView");
-    if ((pageView == '0' || pageView == null) && (profile.cargo == 'Administrador' || profile.cargo == 'Jefe' || profile.cargo == 'Responsable')) {
-      // Initialize page views count
-      pageView = '1';
-    } 
-    else {
-      pageView = '0';
-    }
-    // Update session storage
-    sessionStorage.setItem("pageView", pageView);
-    setCount(pageView);
-  }, []); //No dependency to trigger in each page load
-
-
-
   return (
-    
     <Stack justify="flex-start" sx={(theme) => ({ minHeight: '100%', backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[8] : theme.colors.gray[0], height: 300 })}>
-        {count == '1' &&  <Modal
-          opened={opened}
-          onClose={() => setOpened(false)}
-          title="¡Consumo bajo!"
-          withCloseButton={false}
-        >
-        Se está desaprovechando la potencia contratada, por favor revisa el apartado de estadísticas para más información.
-      </Modal>}
       <GeneralInfo />
       <MapWithNoSSR />
     </Stack>


### PR DESCRIPTION
Se ha quitado el warning de la página de inicio, estaba hardcodeado(porque se usaba para pruebas) y viendo lo que tarda en obtener los datos de la API, mejor no tenerlo, ya que seria muy lento